### PR TITLE
設定ファイルによるテスト実行をサポート

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Config files
+config.json

--- a/README.ja.md
+++ b/README.ja.md
@@ -74,6 +74,28 @@ Claude Desktop設定ファイル（通常は`~/.config/Claude Desktop/claude_des
 npm test
 ```
 
+このテストは設定ファイルを使用してテスト設定を行います。以下の手順に従ってください：
+
+1. サンプル設定ファイルをコピーします：
+   ```bash
+   cp config.sample.json config.json
+   ```
+
+2. `config.json`を編集してプロジェクト設定に合わせます：
+   ```json
+   {
+     "projectId": "YOUR_PROJECT_ID",
+     "location": "us",
+     "testQuery": "SELECT 1",
+     "resourceUri": "bigquery://YOUR_PROJECT_ID/YOUR_DATASET/YOUR_TABLE/schema"
+   }
+   ```
+
+3. テストを実行します：
+   ```bash
+   npm test
+   ```
+
 これにより、以下のテストが実行されます：
 
 - リソース一覧の取得

--- a/README.md
+++ b/README.md
@@ -74,7 +74,29 @@ To verify that the server is working correctly, run:
 npm test
 ```
 
-This will run the following tests:
+This test uses a configuration file for test settings. Follow these steps:
+
+1. Copy the sample configuration file:
+   ```bash
+   cp config.sample.json config.json
+   ```
+
+2. Edit `config.json` to match your project settings:
+   ```json
+   {
+     "projectId": "YOUR_PROJECT_ID",
+     "location": "us",
+     "testQuery": "SELECT 1",
+     "resourceUri": "bigquery://YOUR_PROJECT_ID/YOUR_DATASET/YOUR_TABLE/schema"
+   }
+   ```
+
+3. Run the test:
+   ```bash
+   npm test
+   ```
+
+The test will run the following checks:
 
 - Retrieving resource list
 - Retrieving tool list

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,0 +1,6 @@
+{
+  "projectId": "YOUR_PROJECT_ID",
+  "location": "us",
+  "testQuery": "SELECT 1",
+  "resourceUri": "bigquery://YOUR_PROJECT_ID/YOUR_DATASET/YOUR_TABLE/schema"
+} 

--- a/test/connectivity-test.js
+++ b/test/connectivity-test.js
@@ -2,15 +2,57 @@
 /**
  * BigQuery MCP Server 疎通テストツール
  * MCP ServerとBigQuery間の接続性をテストします
+ * 
+ * 使用方法:
+ * 1. config.sample.jsonをコピーしてconfig.jsonを作成
+ * 2. config.jsonを編集して必要な設定を行う
+ * 3. `node test/connectivity-test.js`を実行
  */
 
 import { spawn } from 'child_process';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+// 設定ファイルを読み込む
+const CONFIG_PATH = join(process.cwd(), 'config.json');
+const SAMPLE_CONFIG_PATH = join(process.cwd(), 'config.sample.json');
+
+// 設定ファイルの存在チェック
+if (!existsSync(CONFIG_PATH)) {
+  console.error('エラー: config.jsonが見つかりません');
+  console.error('config.sample.jsonをコピーしてconfig.jsonを作成し、適切な設定を行ってください');
+  process.exit(1);
+}
+
+// 設定を読み込む
+let config;
+try {
+  const configData = readFileSync(CONFIG_PATH, 'utf8');
+  config = JSON.parse(configData);
+  
+  // 必須項目の確認
+  if (!config.projectId) {
+    throw new Error('projectIdが設定されていません');
+  }
+} catch (error) {
+  console.error(`設定ファイルの読み込みに失敗しました: ${error.message}`);
+  process.exit(1);
+}
+
+// デフォルト値の設定
+config.location = config.location || 'us-central1';
+config.testQuery = config.testQuery || 'SELECT 1';
+config.resourceUri = config.resourceUri || `bigquery://${config.projectId}/dataset/table/schema`;
+
+console.log('設定を読み込みました:');
+console.log(`- プロジェクトID: ${config.projectId}`);
+console.log(`- ロケーション: ${config.location}`);
 
 // サーバープロセスを開始
 const server = spawn('node', [
   'dist/index.js',
-  '--project-id', 'atamaplus-data-workspace',
-  '--location', 'us'
+  '--project-id', config.projectId,
+  '--location', config.location
 ], { 
   stdio: ['pipe', 'pipe', 'pipe'] 
 });
@@ -58,7 +100,7 @@ setTimeout(() => {
         params: {
           name: 'query',
           arguments: {
-            sql: 'SELECT product_name, SUM(price) as total_price FROM `atamaplus-data-workspace.mcp_test.mcp_test_table` GROUP BY product_name ORDER BY total_price DESC LIMIT 5'
+            sql: config.testQuery
           }
         }
       }
@@ -70,7 +112,7 @@ setTimeout(() => {
         id: '5',
         method: 'resources/read',
         params: {
-          uri: 'bigquery://atamaplus-data-workspace/mcp_test/mcp_test_table/schema'
+          uri: config.resourceUri
         }
       }
     }


### PR DESCRIPTION
     ## 変更内容
     テストスクリプト実行の際に設定ファイルから以下の情報を読み込めるようにしました：
     - プロジェクトID
     - ロケーション
     - テストSQL
     - リソースURI
     
     ## 修正対象
     - コマンドライン引数を毎回指定する必要がなくなり、設定を保存しやすくなります
     - 複雑なSQLクエリも設定ファイルに記述できるようになります
     
     ## 使い方
     1. `config.sample.json`をコピーして`config.json`を作成
     2. `config.json`を編集して必要な設定を行う
     3. `npm test`を実行
     
     ## テスト結果
     - [x] テストスクリプトが設定ファイルを正常に読み込み可能
     - [x] テストが正常に実行可能